### PR TITLE
Check if index 0 exists in $matches array

### DIFF
--- a/src/Sonrisa/Component/Sitemap/Validators/UrlValidator.php
+++ b/src/Sonrisa/Component/Sitemap/Validators/UrlValidator.php
@@ -87,7 +87,10 @@ class UrlValidator extends SharedValidator
             && (($priority * 100 % 10) == 0)
         ) {
             preg_match('/([0-9].[0-9])/', $priority, $matches);
-            
+
+            if (! isset($matches[0])){
+                return $data;
+            }
             
             $matches[0] = str_replace(",", ".", floatval($matches[0]));
 

--- a/tests/Sonrisa/Component/Sitemap/Validators/UrlValidatorTest.php
+++ b/tests/Sonrisa/Component/Sitemap/Validators/UrlValidatorTest.php
@@ -125,4 +125,10 @@ class UrlValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $result);
     }
 
+    public function testValidatePriorityInvalid3()
+    {
+        $result = $this->validator->validatePriority(1.0);
+        $this->assertEquals('', $result);
+    }
+
 }


### PR DESCRIPTION
Result of preg_match function can be empty array so we check if index 0 exists. Additional test also added.
