### PR TITLE
fix ImageSitemap won't be written + added tests

### DIFF
--- a/src/Sonrisa/Component/Sitemap/ImageSitemap.php
+++ b/src/Sonrisa/Component/Sitemap/ImageSitemap.php
@@ -124,6 +124,8 @@ class ImageSitemap extends AbstractSitemap implements SitemapInterface
                 $output[] = implode("\n", $fileData);
             }
         }
+        
+        $this->output = $output;
 
         return $output;
     }

--- a/tests/Sonrisa/Component/Sitemap/ImageSitemapTest.php
+++ b/tests/Sonrisa/Component/Sitemap/ImageSitemapTest.php
@@ -248,4 +248,27 @@ XML;
         $files = $this->sitemap->build();
         $this->assertEquals($expected, $files[0]);
     }
+    
+    public function testwriteWithoutBuild()
+    {
+        $item = new \Sonrisa\Component\Sitemap\Items\ImageItem();
+        $item->setLoc('http://www.example.com/logo.png');
+        $item->setCaption('This place is called Limerick, Ireland');
+        $this->sitemap->add($item, 'http://www.example.com/');
+
+        $this->setExpectedException('\\Sonrisa\\Component\\Sitemap\\Exceptions\\SitemapException');
+        $this->sitemap->write('./', 'imagesitemap.xml', false);
+    }
+    
+    public function testWritePlainFile()
+    {
+        $item = new \Sonrisa\Component\Sitemap\Items\ImageItem();
+        $item->setLoc('http://www.example.com/logo.png');
+        $item->setCaption('This place is called Limerick, Ireland');
+        $this->sitemap->add($item, 'http://www.example.com/');
+
+        $this->sitemap->build();
+        $this->sitemap->write('./', 'imagesitemap.xml', false);
+        $this->assertFileExists('imagesitemap.xml');
+    }
 }


### PR DESCRIPTION
the ImageSitemap throws an Exception if you try to write it to files because the output is not stored internally during the build-process.
Addtional tests also added.
