### PR TITLE
Fixes video title validator

### DIFF
--- a/src/Item/Video/VideoItem.php
+++ b/src/Item/Video/VideoItem.php
@@ -131,12 +131,14 @@ class VideoItem extends AbstractItem
      */
     protected function setPlayerLoc($loc, $playerEmbedded, $playerAutoPlay)
     {
-        self::$xml['player_loc'] = VideoItemPlayerTags::setPlayerLoc(
-            $this->validator,
-            $loc,
-            $playerEmbedded,
-            $playerAutoPlay
-        );
+        if ($loc) {
+            self::$xml['player_loc'] = VideoItemPlayerTags::setPlayerLoc(
+                $this->validator,
+                $loc,
+                $playerEmbedded,
+                $playerAutoPlay
+            );            
+        }
 
         return $this;
     }

--- a/src/Item/Video/VideoItem.php
+++ b/src/Item/Video/VideoItem.php
@@ -106,16 +106,18 @@ class VideoItem extends AbstractItem
      */
     protected function setContentLoc($loc)
     {
-        self::writeFullTag(
-            $loc,
-            'content_loc',
-            true,
-            'video:content_loc',
-            $this->validator,
-            'validateContentLoc',
-            $this->exception,
-            'Provided content URL is not a valid.'
-        );
+        if ($loc) {
+            self::writeFullTag(
+                $loc,
+                'content_loc',
+                true,
+                'video:content_loc',
+                $this->validator,
+                'validateContentLoc',
+                $this->exception,
+                'Provided content URL is not a valid.'
+            );
+        }
 
         return $this;
     }

--- a/src/Item/Video/VideoItem.php
+++ b/src/Item/Video/VideoItem.php
@@ -137,7 +137,7 @@ class VideoItem extends AbstractItem
                 $loc,
                 $playerEmbedded,
                 $playerAutoPlay
-            );            
+            );
         }
 
         return $this;

--- a/src/Item/Video/VideoItemValidator.php
+++ b/src/Item/Video/VideoItemValidator.php
@@ -65,11 +65,16 @@ class VideoItemValidator
     /**
      * @param $title
      *
-     * @return bool
+     * @return string|false
      */
     public function validateTitle($title)
     {
-        return self::validateString($title) && \strlen($title) < 97;
+        $length = \mb_strlen($title, 'UTF-8');
+        if ($length > 0 && $length < 97) {
+            return self::validateString($title);
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Fixes #45 

Updates VideoItemValidator:: validateTitle() to return the video title instead of true when the video title is the correct length, and false when it is too long or empty. 